### PR TITLE
Added simple Dockerfile and docker-compose.yml for Dockerizing mirotalk

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,18 @@
+# git folder
+**/.git
+
+# npm
+node_modules
+npm-debug.log
+
+# package
+package-lock.json
+
+# mac
+.DS_Store
+
+# cache
+.cache
+
+# personal env
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:12
+
+WORKDIR /usr/src/app
+
+COPY package*.json ./
+COPY .env.template ./.env
+
+RUN npm install
+
+COPY . .
+
+EXPOSE 3000
+
+CMD [ "npm", "start" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,26 @@
+version: '3'
+
+services:
+  mirotalk:
+    image: mirotalk:latest
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: mirotalk
+    hostname: mirotalk
+    volumes:
+      - .env:/usr/src/app/.env:ro
+    restart: unless-stopped
+    ports:
+      - "3000:3000"
+# Uncomment below, remove "ports:" section above and configure labels as
+# needed for LetsEncrypt TLS certificates with Traefik.
+# See https://doc.traefik.io/traefik/user-guides/docker-compose/basic-example/
+#   expose:
+#     - 3000
+#   labels:
+#     - "traefik.enable=true"
+#     - "traefik.http.routers.mirotalk.rule=Host(`mirotalk.example.com`)"
+#     - "traefik.http.routers.mirotalk.entrypoints=websecure"
+#     - "traefik.http.routers.mirotalk.tls.certresolver=myresolver"
+#     - "traefik.http.services.mirotalk.loadbalancer.server.port=3000"


### PR DESCRIPTION
Basic Dockerfile, docker-compose.yml and .dockerignore files for running Mirotalk. I've tested it locally over http port 3000 and on a VPS using traefik to get a LetsEncrypt TLS certificate and use HTTPS with reverse proxying and it worked fine.