### PR TITLE
Add workflow to push image to Github Container Registry (latest and version)

### DIFF
--- a/.github/workflows/docker_latest.yaml
+++ b/.github/workflows/docker_latest.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - master
 
 jobs:
   build-and-push-image:

--- a/.github/workflows/docker_latest.yaml
+++ b/.github/workflows/docker_latest.yaml
@@ -1,0 +1,35 @@
+name: Latest
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Lower case Repo name
+        id: string
+        uses: ASzc/change-string-case-action@v5
+        with:
+          string: ${{ github.repository }}
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ghcr.io/${{ steps.string.outputs.lowercase }}
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          tags: ghcr.io/${{ steps.string.outputs.lowercase }}:latest
+          push: true

--- a/.github/workflows/docker_version.yaml
+++ b/.github/workflows/docker_version.yaml
@@ -1,0 +1,32 @@
+name: Version
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Lower case Repo name
+        id: string
+        uses: ASzc/change-string-case-action@v5
+        with:
+          string: ${{ github.repository }}
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Get the version
+        id: vars
+        run: echo ::set-output name=tag::$(echo ${GITHUB_REF:10})
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          tags: ghcr.io/${{ steps.string.outputs.lowercase }}:${{steps.vars.outputs.tag}}
+          push: true


### PR DESCRIPTION
As there is no Docker image for this repository, I created two workflows that will use the Github Container Registry to build and push images for it.

This PR will add two workflows:

- Latest: Will push to "latest" tag on every push to main/master 
- Version: Will push to a new (versioned) tag once a release is created