### PR TITLE
HOST env variable added

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -6,6 +6,10 @@ HTTPS=false
 
 PORT=3000
 
+# Domain
+
+HOST=localhost
+
 # Ngrok
 # 1. Goto https://ngrok.com
 # 2. Get started for free 

--- a/app/src/server.js
+++ b/app/src/server.js
@@ -54,10 +54,12 @@ const app = express();
 const Logs = require('./logs');
 const log = new Logs('server');
 
-const isHttps = process.env.HTTPS == 'true' ? true : false;
+const domain = process.env.HOST || 'localhost'
+const isHttps = process.env.HTTPS == 'true';
 const port = process.env.PORT || 3000; // must be the same to client.js signalingServerPort
+const host = `http${isHttps ? 's' : ''}://${domain}:${port}`
 
-let io, server, host;
+let io, server;
 
 if (isHttps) {
     const fs = require('fs');
@@ -66,10 +68,8 @@ if (isHttps) {
         cert: fs.readFileSync(path.join(__dirname, '../ssl/cert.pem'), 'utf-8'),
     };
     server = https.createServer(options, app);
-    host = 'https://' + 'localhost' + ':' + port;
 } else {
     server = http.createServer(app);
-    host = 'http://' + 'localhost' + ':' + port;
 }
 
 /*  


### PR DESCRIPTION
It used to listen on `localhost` only.

This PR enhance the code and make users to be able to set HOST env variable to change listening host.