### PR TITLE
added PRIORITIZE_H264 env

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -109,6 +109,6 @@ CHATGPT_MODEL=text-davinci-003
 CHATGPT_MAX_TOKENS=1000
 CHATGPT_TEMPERATURE=0
 
-# give priority to h264/aac when
-# recording screen
-PRIORITIZE_H264=false # true or false
+# Recording
+# Give priority to h264,aac|h264,opus instead of vp8,opus/vp9,opus codec
+REC_PRIORITIZE_H264=false # true or false

--- a/.env.template
+++ b/.env.template
@@ -108,3 +108,7 @@ CHATGTP_APIKEY=YourOpenAiApiKey
 CHATGPT_MODEL=text-davinci-003
 CHATGPT_MAX_TOKENS=1000
 CHATGPT_TEMPERATURE=0
+
+# give priority to h264/aac when
+# recording screen
+PRIORITIZE_H264=false # true or false

--- a/app/src/server.js
+++ b/app/src/server.js
@@ -206,8 +206,8 @@ if (configChatGPT.enabled) {
     }
 }
 
-// make sure we prioritize h264/aac when recording screen
-const isPrioritizeH264 = getEnvBoolean(process.env.PRIORITIZE_H264)
+// make sure we prioritize h264,aac/h264,opus when recording
+const recPrioritizeH264 = getEnvBoolean(process.env.REC_PRIORITIZE_H264);
 
 // directory
 const dir = {
@@ -541,6 +541,7 @@ async function ngrokStart() {
             sentry_enabled: sentryEnabled,
             survey_enabled: surveyEnabled,
             redirect_enabled: redirectEnabled,
+            rec_prioritize_h264: recPrioritizeH264,
             survey_url: surveyURL,
             redirect_url: redirectURL,
             node_version: process.versions.node,
@@ -590,6 +591,7 @@ server.listen(port, null, () => {
             sentry_enabled: sentryEnabled,
             survey_enabled: surveyEnabled,
             redirect_enabled: redirectEnabled,
+            rec_prioritize_h264: recPrioritizeH264,
             survey_url: surveyURL,
             redirect_url: redirectURL,
             node_version: process.versions.node,
@@ -838,7 +840,7 @@ io.sockets.on('connect', async (socket) => {
                 active: redirectEnabled,
                 url: redirectURL,
             },
-	    is_prioritize_h264: isPrioritizeH264,
+            rec_prioritize_h264: recPrioritizeH264,
             //...
         });
     });

--- a/app/src/server.js
+++ b/app/src/server.js
@@ -206,6 +206,9 @@ if (configChatGPT.enabled) {
     }
 }
 
+// make sure we prioritize h264/aac when recording screen
+const isPrioritizeH264 = getEnvBoolean(process.env.PRIORITIZE_H264)
+
 // directory
 const dir = {
     public: path.join(__dirname, '../../', 'public'),
@@ -835,6 +838,7 @@ io.sockets.on('connect', async (socket) => {
                 active: redirectEnabled,
                 url: redirectURL,
             },
+	    is_prioritize_h264: isPrioritizeH264,
             //...
         });
     });

--- a/public/js/client.js
+++ b/public/js/client.js
@@ -496,7 +496,6 @@ let swBg = 'rgba(0, 0, 0, 0.7)'; // swAlert background color
 let callElapsedTime; // count time
 let mySessionTime; // conference session time
 let isDocumentOnFullScreen = false;
-let isPrioritizeH264 = false;
 
 // peer
 let myPeerId; // This socket.id
@@ -604,6 +603,7 @@ let audioRecorder; // helpers.js
 let recScreenStream; // screen media to recording
 let recTimer;
 let recElapsedTime;
+let recPrioritizeH264 = false;
 let isStreamRecording = false;
 let isStreamRecordingPaused = false;
 let isRecScreenStream = false;
@@ -1127,7 +1127,7 @@ async function handleConnect() {
 function handleServerInfo(config) {
     console.log('13. Server info', config);
 
-    const { peers_count, host_protected, user_auth, is_presenter, survey, redirect, is_prioritize_h264 } = config;
+    const { peers_count, host_protected, user_auth, is_presenter, survey, redirect, rec_prioritize_h264 } = config;
 
     isHostProtected = host_protected;
     isPeerAuthEnabled = user_auth;
@@ -1149,7 +1149,7 @@ function handleServerInfo(config) {
     isPeerPresenter.innerText = isPresenter;
 
     // prioritize h264
-    isPrioritizeH264 = is_prioritize_h264;
+    recPrioritizeH264 = rec_prioritize_h264;
 
     if (isRulesActive) {
         handleRules(isPresenter);
@@ -5746,17 +5746,9 @@ function stopRecordingTimer() {
  * @returns {boolean} is mimeType supported by media recorder
  */
 function getSupportedMimeTypes() {
-    const possibleTypes = [
-        'video/webm;codecs=vp9,opus',
-        'video/webm;codecs=vp8,opus',
-        'video/mp4',
-    ];
-    possibleTypes.splice(
-        isPrioritizeH264 ? 0 : 2,
-        0,
-        'video/mp4;codecs=h264,aac',
-        'video/webm;codecs=h264,opus'
-    );
+    const possibleTypes = ['video/webm;codecs=vp9,opus', 'video/webm;codecs=vp8,opus', 'video/mp4'];
+    possibleTypes.splice(recPrioritizeH264 ? 0 : 2, 0, 'video/mp4;codecs=h264,aac', 'video/webm;codecs=h264,opus');
+    console.log('POSSIBLE CODECS', possibleTypes);
     return possibleTypes.filter((mimeType) => {
         return MediaRecorder.isTypeSupported(mimeType);
     });

--- a/public/js/client.js
+++ b/public/js/client.js
@@ -496,6 +496,7 @@ let swBg = 'rgba(0, 0, 0, 0.7)'; // swAlert background color
 let callElapsedTime; // count time
 let mySessionTime; // conference session time
 let isDocumentOnFullScreen = false;
+let isPrioritizeH264 = false;
 
 // peer
 let myPeerId; // This socket.id
@@ -1126,7 +1127,7 @@ async function handleConnect() {
 function handleServerInfo(config) {
     console.log('13. Server info', config);
 
-    const { peers_count, host_protected, user_auth, is_presenter, survey, redirect } = config;
+    const { peers_count, host_protected, user_auth, is_presenter, survey, redirect, is_prioritize_h264 } = config;
 
     isHostProtected = host_protected;
     isPeerAuthEnabled = user_auth;
@@ -1146,6 +1147,9 @@ function handleServerInfo(config) {
     // Let start with some basic rules
     isPresenter = isPeerReconnected ? isPresenter : is_presenter;
     isPeerPresenter.innerText = isPresenter;
+
+    // prioritize h264
+    isPrioritizeH264 = is_prioritize_h264;
 
     if (isRulesActive) {
         handleRules(isPresenter);
@@ -5745,10 +5749,14 @@ function getSupportedMimeTypes() {
     const possibleTypes = [
         'video/webm;codecs=vp9,opus',
         'video/webm;codecs=vp8,opus',
-        'video/webm;codecs=h264,opus',
-        'video/mp4;codecs=h264,aac',
         'video/mp4',
     ];
+    possibleTypes.splice(
+        isPrioritizeH264 ? 0 : 2,
+        0,
+        'video/mp4;codecs=h264,aac',
+        'video/webm;codecs=h264,opus'
+    );
     return possibleTypes.filter((mimeType) => {
         return MediaRecorder.isTypeSupported(mimeType);
     });


### PR DESCRIPTION
while recording, mirotalk selects vp9,vp8 then goes to h264. most of the modern browsers support vp9/vp8, but vp9/vp8 becomes issue when postprocessing, hardware accelerated encoding/decoding is limited for vp9/vp8, so this env will prioritize h264/aac before moving to other possibilities.