### PR TITLE
Keep require() behavior

### DIFF
--- a/app/src/server.js
+++ b/app/src/server.js
@@ -2104,15 +2104,11 @@ function removeIP(socket) {
  * @returns
  */
 function safeRequire(filePath) {
+    let data = null;
     try {
-        // Resolve the absolute path of the module
-        const resolvedPath = require.resolve(filePath);
-        // Check if the file exists
-        if (fs.existsSync(resolvedPath)) {
-            return require(resolvedPath);
-        }
+	data = require(filePath);
     } catch (error) {
-        log.error('Module not found', filePath);
+        log.error(error);
     }
-    return null;
+    return data;
 }


### PR DESCRIPTION
This will allow to require .js and .json when no extension is given Also does not swallow potential file parsing errors

For more background, this came up with the requiring of the new branding `config` which caused some debugging time since the error message was misleading.