### PR TITLE
Remove redundant check for meetings initialization

### DIFF
--- a/app/src/api.js
+++ b/app/src/api.js
@@ -39,9 +39,6 @@ module.exports = class ServerApi {
         const meetings = {};
         for (const room_id in peers) {
             const meeting = peers[room_id];
-            if (!meetings) {
-                meetings = {};
-            }
             meetings[room_id] = meeting;
         }
         return meetings;


### PR DESCRIPTION
## PR Summary
This PR removes a redundant conditional check for the meetings object, which is already initialized. This cleanup prevents unnecessary code and avoids a potential `const` reassignment issue.