### PR TITLE
fix(typo): correct .env.template and trim trailing whitespace

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -23,7 +23,7 @@ LOGS_JSON=false # true or false
 LOGS_JSON_PRETTY=false # true or false
 
 # Cors
-# Origin: Allow specified origin es '["https://example.com", "https://subdomain.example.com", "http://localhost:3000"]' or 
+# Origin: Allow specified origin es '["https://example.com", "https://subdomain.example.com", "http://localhost:3000"]' or
 # all origins '*' if not specified as per default.
 # Methods: Allow only GET and POST methods
 
@@ -56,7 +56,7 @@ SESSION_SECRET='mirotalk-p2p-oidc-secret'
 ROOM_MAX_PARTICIPANTS=1000
 
 # Host protection
-# HOST_PROTECTED: 
+# HOST_PROTECTED:
 #		- When set to true, it requires a valid username and password from the HOST_USERS list to initialize or join a room.
 #		- When OIDC_ENABLED is utilized alongside host protection, the authenticated user will be recognized as valid.# HOST_USER_AUTH: When set to true, it also requires a valid username and password for joining the room.
 # HOST_USERS: This is the list of valid users along with their credentials.
@@ -71,14 +71,14 @@ JWT_KEY=mirotalkp2p_jwt_secret
 JWT_EXP=1h
 
 # Presenters list
-# In our virtual room, the first participant to join will assume the role of the presenter. 
+# In our virtual room, the first participant to join will assume the role of the presenter.
 # Additionally, we have the option to include more presenters and co-presenters, each identified by their username.
 
 PRESENTERS='["Miroslav Pejic", "miroslav.pejic.85@gmail.com"]'
 
 # Ngrok
 # 1. Goto https://ngrok.com
-# 2. Get started for free 
+# 2. Get started for free
 # 3. Copy YourNgrokAuthToken: https://dashboard.ngrok.com/get-started/your-authtoken
 
 NGROK_ENABLED=false # true or false
@@ -91,7 +91,7 @@ NGROK_AUTH_TOKEN=YourNgrokAuthToken
 STUN_SERVER_ENABLED=true # true or false
 STUN_SERVER_URL=stun:stun.l.google.com:19302
 
-# Turn 
+# Turn
 # About: https://bloggeek.me/webrtcglossary/turn/
 # Recommended: https://github.com/coturn/coturn
 # Installation: https://github.com/miroslavpejic85/mirotalk/blob/master/docs/coturn.md
@@ -116,14 +116,14 @@ IP_LOOKUP_ENABLED=false # true or false
 API_KEY_SECRET=mirotalkp2p_default_secret
 API_DISABLED='["token", "meetings"]'
 
-# Survey URL 
+# Survey URL
 # Using to redirect the client after close the call (feedbacks, website...)
 
 SURVEY_ENABLED=true # true or false
 SURVEY_URL=https://www.questionpro.com/t/AUs7VZq00L
 
 # Redirect URL on leave room
-# Upon leaving the room, users who either opt out of providing feedback or if the survey is disabled 
+# Upon leaving the room, users who either opt out of providing feedback or if the survey is disabled
 # will be redirected to a specified URL. If enabled false the default '/newrcall' URL will be used.
 
 REDIRECT_ENABLED=false # true or false
@@ -163,7 +163,7 @@ MATTERMOST_ENABLED=false # true or false
 MATTERMOST_SERVER_URL=YourMattermostServerUrl
 MATTERMOST_USERNAME=YourMattermostUsername
 MATTERMOST_PASSWORD=YourMattermostPassword
-MATTERMOST_TOKEN=YourMettarmostToken
+MATTERMOST_TOKEN=YourMattermostToken
 MATTERMOST_ROOM_TOKEN_EXPIRE=15m
 
 # ChatGPT/OpenAI


### PR DESCRIPTION
fix typo:

```diff
- MATTERMOST_TOKEN=YourMettarmostToken
+ MATTERMOST_TOKEN=YourMattermostToken
```