### PR TITLE
Feature : Delete Btn Feature Created

### DIFF
--- a/public/js/client.js
+++ b/public/js/client.js
@@ -12632,6 +12632,34 @@ function setupWhiteboardShortcuts() {
             event.preventDefault();
             return;
         }
+        // Whiteboard delete shortcut: Delete / Backspace
+        if (event.key === 'Delete') {
+            const activeObj = wbCanvas?.getActiveObject?.();
+            if (!activeObj) return;
+
+            // Ignore normal typing in inputs (chat, forms, etc.)
+            const tag = document.activeElement?.tagName;
+            const isTypingInInput = tag === 'INPUT' || tag === 'TEXTAREA';
+
+            const isTextObj = ['i-text', 'textbox', 'text'].includes(activeObj.type);
+            const isFabricTextEditing = isTextObj && activeObj.isEditing;
+
+            if (isTypingInInput && !isFabricTextEditing) return;
+
+            event.preventDefault();
+
+            // Exit text editing mode first
+            if (isFabricTextEditing && typeof activeObj.exitEditing === 'function') {
+                activeObj.exitEditing();
+                activeObj.selectable = true;
+            }
+
+            wbCanvas.setActiveObject(activeObj);
+
+            // Use existing erase logic (keeps sync + undo behavior consistent)
+            whiteboardEraseObject();
+            return;
+        }
 
         // Use event.code and check for Alt+Meta (Mac) or Alt+Ctrl (Windows/Linux)
         if (event.code && event.altKey && (event.ctrlKey || event.metaKey) && !event.shiftKey) {


### PR DESCRIPTION
### **Problem**
Previously, the whiteboard did not support deleting selected objects using the Delete key. Even when one or multiple objects (shapes, drawings, or text objects) were selected, pressing Delete had no effect. Users were forced to rely on toolbar actions or other indirect methods to remove objects, which made editing slower and unintuitive especially for users accustomed to standard drawing or design tools.

### **Solution**
A keyboard-based delete handling was added to the whiteboard. Now, when one or more objects are selected on the canvas, pressing the Delete key removes all selected objects at once. This works consistently for shapes, hand-drawn elements, and text objects (when not in text-editing mode).
The fix improves usability, speeds up editing, and brings the whiteboard behavior in line with common UX expectations found in tools like Figma, PowerPoint, or Miro.


https://github.com/user-attachments/assets/395db3d4-4e49-4603-b187-c073f63d7874

