### PR TITLE
Fix: speech bar on user join.

### DIFF
--- a/public/js/client.js
+++ b/public/js/client.js
@@ -2577,6 +2577,9 @@ async function whoAreYouJoin() {
     if (isScreenStreaming && useVideo) {
         await changeLocalCamera(videoSelect.value);
     }
+    if (useAudio && localAudioMediaStream) {
+        getMicrophoneVolumeIndicator(localAudioMediaStream);
+    }
 }
 
 /**


### PR DESCRIPTION
The speech volume bar now appears as soon as the user joins the room. 

This was done because when in the presence of more than one other user, it gets difficult to see who's talking.